### PR TITLE
Fix menu icons, add software philosophy, update research page

### DIFF
--- a/assets/css/images/arrow.svg
+++ b/assets/css/images/arrow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" width="30px" height="30px" viewBox="0 0 30 30" zoomAndPan="disable" preserveAspectRatio="none">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="30px" height="30px" viewBox="0 0 30 30" zoomAndPan="disable" preserveAspectRatio="none">
     <style type="text/css"><![CDATA[ line { stroke: #ffffff; stroke-width: 3; } ]]></style>
 	<line x1="0" y1="15" x2="15" y2="30" />
 	<line x1="30" y1="15" x2="15" y2="30" />

--- a/assets/css/images/bars.svg
+++ b/assets/css/images/bars.svg
@@ -1,4 +1,4 @@
-<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" width="16px" height="16px" viewBox="0 0 16 16" zoomAndPan="disable" preserveAspectRatio="none">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16px" height="16px" viewBox="0 0 16 16" zoomAndPan="disable" preserveAspectRatio="none">
     <style type="text/css"><![CDATA[ line { stroke: #ffffff; stroke-width: 2; } ]]></style>
 	<line x1="0" y1="1" x2="16" y2="1" />
 	<line x1="0" y1="7" x2="16" y2="7" />

--- a/assets/css/images/close.svg
+++ b/assets/css/images/close.svg
@@ -1,4 +1,4 @@
-<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" width="16px" height="16px" viewBox="0 0 16 16" zoomAndPan="disable" preserveAspectRatio="none">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16px" height="16px" viewBox="0 0 16 16" zoomAndPan="disable" preserveAspectRatio="none">
     <style type="text/css"><![CDATA[ line { stroke: #ffffff; stroke-width: 2; } ]]></style>
 	<line x1="0" y1="0" x2="16" y2="16" />
 	<line x1="16" y1="0" x2="0" y2="16" />

--- a/assets/webfonts/fa-brands-400.svg
+++ b/assets/webfonts/fa-brands-400.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
 <metadata>
 Created by FontForge 20201107 at Wed Aug  4 12:25:29 2021
  By Robert Madole

--- a/assets/webfonts/fa-regular-400.svg
+++ b/assets/webfonts/fa-regular-400.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
 <metadata>
 Created by FontForge 20201107 at Wed Aug  4 12:25:29 2021
  By Robert Madole

--- a/assets/webfonts/fa-solid-900.svg
+++ b/assets/webfonts/fa-solid-900.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
 <metadata>
 Created by FontForge 20201107 at Wed Aug  4 12:25:29 2021
  By Robert Madole

--- a/images/plot-1Ds.svg
+++ b/images/plot-1Ds.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" width="600" height="400" viewBox="0 0 2400 1600">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="400" viewBox="0 0 2400 1600">
 <defs>
   <clipPath id="clip900">
     <rect x="0" y="0" width="2400" height="1600"/>

--- a/research.html
+++ b/research.html
@@ -111,18 +111,18 @@
 
 					<hr />
 
-					<h3>Structural biology of intrinsically disordered proteins</h3>
-					<p><span class="image right"><img src="images/kleo-talk.jpg" alt="" /></span>
-						Many functionally important proteins, and regions of proteins, lack a single well-defined
-						structure, instead sampling a dynamic ensemble of conformations. We use NMR spectroscopy to
-						characterise these disordered states, and how they interconvert with order to perform their
-						biological roles.
+					<h3>ER glycan quality control</h3>
+					<p>
+						The endoplasmic reticulum relies on an elaborate glycan-dependent quality control system to
+						ensure that only correctly folded proteins progress through the secretory pathway, with
+						molecular chaperones such as calnexin and calreticulin acting as key sensors of folding
+						status. We are interested in the structural biology of this machinery, and in how it
+						distinguishes native from non-native states.
 					</p>
 					<p>
-						Current work focuses on calreticulin, an ER-resident chaperone and key component of the
-						glycoprotein quality control pathway, where we are investigating the interplay of order and
-						disorder within its C-terminal domain and its relationship to calcium-binding and chaperone
-						function.
+						Current work focuses on calreticulin, where we are using NMR spectroscopy to investigate the
+						interplay of order and disorder within its C-terminal domain and its relationship to
+						calcium-binding and chaperone function.
 					</p>
 
 					<hr />

--- a/research.html
+++ b/research.html
@@ -10,6 +10,15 @@
 	<title>The Waudby Group | Research</title>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+	<meta name="description"
+		content="Research from the Waudby Group at UCL: NMR lineshape analysis, 19F fragment-based drug discovery, structural biology of intrinsically disordered proteins, protein folding on the ribosome, and ex vivo NMR of disease-associated proteins." />
+	<link rel="canonical" href="https://waudbylab.org/research.html" />
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content="The Waudby Group | Research" />
+	<meta property="og:description"
+		content="NMR lineshape analysis, 19F fragment-based drug discovery, intrinsically disordered proteins, co-translational protein folding and ex vivo NMR from the Waudby Group." />
+	<meta property="og:url" content="https://waudbylab.org/research.html" />
+	<meta property="og:image" content="https://waudbylab.org/images/r1rho.png" />
 	<link rel="stylesheet" href="assets/css/main.css" />
 	<noscript>
 		<link rel="stylesheet" href="assets/css/noscript.css" />
@@ -83,6 +92,41 @@
 
 					<hr />
 
+					<h3>Fragment-based drug discovery</h3>
+					<p><span class="image left"><img src="images/r1rho.png" alt="" /></span>
+						Fragment screening identifies weak-binding starting points for drug discovery, but
+						conventional screens are slow and often struggle to detect fast-dissociating hits. We have
+						developed a kinetic <sup>19</sup>F NMR approach, using R<sub>1&rho;</sub> relaxation
+						dispersion of fluorinated fragment cocktails, that rapidly quantifies ligand dissociation
+						rates directly within mixtures &mdash; considerably accelerating hit identification and
+						triage.
+					</p>
+					<p>
+						This work underpins our in-house <a
+							href="https://www.ucl.ac.uk/life-sciences/pharmacy/about/facilities/sop-nuclear-magnetic-resonance-nmr-facility/19f-nmr-fragment-screening-platform">19F
+							NMR Fragment Screening Platform</a>, and is implemented in our open-source <a
+							href="software.html#NMRScreen">NMRScreen.jl</a> package, making the method accessible to
+						medicinal chemists and structural biologists without specialist NMR expertise.
+					</p>
+
+					<hr />
+
+					<h3>Structural biology of intrinsically disordered proteins</h3>
+					<p><span class="image right"><img src="images/kleo-talk.jpg" alt="" /></span>
+						Many functionally important proteins, and regions of proteins, lack a single well-defined
+						structure, instead sampling a dynamic ensemble of conformations. We use NMR spectroscopy to
+						characterise these disordered states, and how they interconvert with order to perform their
+						biological roles.
+					</p>
+					<p>
+						Current work focuses on calreticulin, an ER-resident chaperone and key component of the
+						glycoprotein quality control pathway, where we are investigating the interplay of order and
+						disorder within its C-terminal domain and its relationship to calcium-binding and chaperone
+						function.
+					</p>
+
+					<hr />
+
 					<h3>NMR dynamics & methodology</h3>
 					<p><span class="image right"><img src="images/qq.png" alt="" /></span>
 						We continue to push the capabilities of NMR spectroscopy with the
@@ -123,7 +167,11 @@
 						advanced NMR methods, we have begun to make progress in understanding the evolution
 						of the free-energy landscape as a nascent chain emerges from the ribosome, and the
 						major role that interactions between the nascent chain and ribosome surface can have on the
-						folding process.
+						folding process. Continuing this collaboration, recent work has shown that the ribosome
+						itself lowers the entropic penalty of protein folding (<a
+							href="https://www.nature.com/articles/s41586-024-07784-4"><i>Nature</i>, 2024</a>), and
+						that long-range electrostatic forces govern how proteins fold on the ribosome (<a
+							href="https://doi.org/10.1101/2025.02.10.637539"><i>bioRxiv</i>, 2025</a>).
 					</p>
 
 					<h4>Ex vivo NMR</h4>
@@ -141,7 +189,26 @@
 						<strong>patient-derived</strong> samples of wild-type and disease-associated α<sub>1</sub>AT
 						variants using 2D <sup>1</sup>H,<sup>13</sup>C NMR at natural abundance. This provides
 						access to natively-glycosylated variants that often cannot be expressed recombinantly,
-						providing important insights into the conformation and dynamics of α<sub>1</sub>AT in solution.
+						providing important insights into the conformation and dynamics of α<sub>1</sub>AT in
+						solution, published in <a href="https://doi.org/10.1126/sciadv.adu7064"><i>Science
+								Advances</i> (2025)</a>.
+					</p>
+
+					<hr />
+
+					<h3>Open, reproducible NMR</h3>
+					<p>
+						Good software and good data practices are as important to reproducible NMR research as the
+						experiments themselves. We develop our analysis tools openly, primarily in <a
+							href="https://www.julialang.org">Julia</a>, and release them under permissive licences
+						&mdash; see our <a href="software.html">Software</a> page for NMR TITAN, NMRTools.jl,
+						NMRAnalysis.jl, NMRScreen.jl and more.
+					</p>
+					<p>
+						We're also developing an open, versioned schema for recording sample metadata &mdash;
+						composition, buffers, tube details and lab references &mdash; alongside NMR experiment data,
+						to make it easier to interpret, reproduce and deposit NMR datasets in line with FAIR
+						principles.
 					</p>
 
 					<hr />
@@ -157,6 +224,7 @@
 						<li>Peters group (Lübeck)</li>
 						<li>Pielak group (UNC Chapel Hill)</li>
 						<li>Tripsianes group (Brno)</li>
+						<li>Waller group (UCL)</li>
 					</ul>
 					<p>Please get in touch if you have a problem you'd like to work together on!</p>
 					<ul class="actions stacked">

--- a/software.html
+++ b/software.html
@@ -65,6 +65,12 @@
 		<article id="main">
 			<header>
 				<h2>Software</h2>
+				<p>
+					We believe good software should be free, open and built with the community, not just for it.
+					Wherever possible we develop our tools in the open on GitHub, primarily in
+					<a href="https://www.julialang.org">Julia</a>, and release them under permissive licences so
+					that other labs can use, adapt and contribute to them.
+				</p>
 				<ul class="actions special">
 					<li><a href="#TITAN" class="button">NMR TITAN</a></li>
 					<li><a href="#AktaPrime" class="button">AktaPrime.jl</a></li>


### PR DESCRIPTION
## Summary
- Fix invisible hamburger/close menu icons sitewide: the SVG `xmlns` was declared as `https://www.w3.org/2000/svg` instead of the required `http://`, an invalid namespace that browsers refuse to render as an image (still clickable, just invisible). Fixed in all affected SVGs.
- Add a short philosophy statement to the Software page: open development on GitHub, primarily in Julia, released under permissive licences.
- Update the Research page to reflect current group activities: add "Fragment-based drug discovery" (¹⁹F NMR relaxation dispersion screening, NMRScreen.jl) and "ER glycan quality control" (calreticulin) sections that were missing entirely; link recent publications (Nature 2024, bioRxiv 2025, Science Advances 2025) into the existing protein folding and ex vivo NMR sections; add a short "Open, reproducible NMR" section; add Waller group (UCL) to collaborations; add meta description/OG tags.

## Test plan
- [x] Verified the menu/close icons render correctly with a headless-browser screenshot before/after the SVG fix
- [x] Rendered the updated Research and Software pages locally and visually reviewed each section/image


---
_Generated by [Claude Code](https://claude.ai/code/session_01HGfMANC4459Gi4gYa8Kh6k)_